### PR TITLE
Feat size

### DIFF
--- a/src/ofxThreadedLogger.cpp
+++ b/src/ofxThreadedLogger.cpp
@@ -30,14 +30,17 @@ LoggerThread::LoggerThread(string logDirPath, string logfilename)
 	
 LoggerThread::~LoggerThread() {
 	// Stop the thread if it's still running
+#ifdef LOGGER_THREAD_DEBUG
 	ofLog(OF_LOG_VERBOSE, "LoggerThread::~LoggerThread()");
+#endif
 	stopThread();
 }
 
 void LoggerThread::stopThread()
 {
+#ifdef LOGGER_THREAD_DEBUG
 	ofLog(OF_LOG_VERBOSE, "LoggerThread::stopThread()");
-	//ofThread::stopThread();
+#endif
 	if (isThreadRunning()) {
 		waitForThread(true);
 	}
@@ -65,11 +68,11 @@ void LoggerThread::log(string logString) {
 	ofDirectory dir(_logDirPath);
 	dir.create(true);
 	//_mkdir( _logDirPath.c_str() );//, S_IRWXU | S_IRWXG | S_IRWXO);
-    string filename = _logDirPath + _logfilename;
-    ofstream mFile;
+  string filename = _logDirPath + _logfilename;
+  ofstream mFile;
 	mFile.open(filename.c_str(), ios::out | ios::app);
 	mFile << logString;
-    mFile.close();
+  mFile.close();
 }
 
 void LoggerThread::pop() {
@@ -100,9 +103,9 @@ void LoggerThread::push(string logString)
 		while (pushQueue->size() > 0 || popQueue->size() > 0)
 		{
 			ofSleepMillis(_loopSleep / 2);
-			#ifdef LOGGER_THREAD_DEBUG 
+#ifdef LOGGER_THREAD_DEBUG 
 			cout << "*";
-			#endif
+#endif
 		}
 	}
 
@@ -190,5 +193,7 @@ size_t LoggerThread::size(LoggerQueue lq)
 
 void LoggerThread::setPushThrottlingSize(size_t pushThrottlingSize)
 {
+	lock();
 	_pushThrottlingSize = pushThrottlingSize;
+	unlock();
 }

--- a/src/ofxThreadedLogger.cpp
+++ b/src/ofxThreadedLogger.cpp
@@ -30,14 +30,17 @@ LoggerThread::LoggerThread(string logDirPath, string logfilename)
 	
 LoggerThread::~LoggerThread() {
 	// Stop the thread if it's still running
-	waitForThread(true);
-	swapQueues();
-	popAll();
+	ofLog(OF_LOG_VERBOSE, "LoggerThread::~LoggerThread()");
+	stopThread();
 }
 
 void LoggerThread::stopThread()
 {
-	waitForThread(true);
+	ofLog(OF_LOG_VERBOSE, "LoggerThread::stopThread()");
+	//ofThread::stopThread();
+	if (isThreadRunning()) {
+		waitForThread(true);
+	}
 	swapQueues();
 	popAll();
 }

--- a/src/ofxThreadedLogger.cpp
+++ b/src/ofxThreadedLogger.cpp
@@ -94,6 +94,18 @@ void LoggerThread::popAll()
 
 void LoggerThread::push(string logString) 
 {
+	// ToDo: There may be ways to substantially optimize the push throttling
+	if (pushQueue->size() > _pushThrottlingSize || popQueue->size() > _pushThrottlingSize)
+	{
+		while (pushQueue->size() > 0 || popQueue->size() > 0)
+		{
+			ofSleepMillis(1);
+			#ifdef LOGGER_THREAD_DEBUG 
+			cout << "*";
+			#endif
+		}
+	}
+
 	lock();
 	pushQueue->push(logString);
 	unlock();
@@ -174,4 +186,9 @@ size_t LoggerThread::size(LoggerQueue lq)
 	}
 	unlock();
 	return out;
+}
+
+void LoggerThread::setPushThrottlingSize(size_t pushThrottlingSize)
+{
+	_pushThrottlingSize = pushThrottlingSize;
 }

--- a/src/ofxThreadedLogger.cpp
+++ b/src/ofxThreadedLogger.cpp
@@ -99,7 +99,7 @@ void LoggerThread::push(string logString)
 	{
 		while (pushQueue->size() > 0 || popQueue->size() > 0)
 		{
-			ofSleepMillis(1);
+			ofSleepMillis(_loopSleep / 2);
 			#ifdef LOGGER_THREAD_DEBUG 
 			cout << "*";
 			#endif
@@ -127,7 +127,7 @@ void LoggerThread::threadedFunction()
 		// pop queue is now safe from push thread collisions
 		popAll();
 
-		sleep(4);
+		sleep(_loopSleep);
 	}
 }
 

--- a/src/ofxThreadedLogger.cpp
+++ b/src/ofxThreadedLogger.cpp
@@ -156,3 +156,19 @@ string LoggerThread::fileDateTimeString(unsigned long long ofTime)
 
 	return output;
 }
+
+size_t LoggerThread::size(LoggerQueue lq)
+{
+	size_t out;
+	lock();
+	if (lq == LoggerQueue::PUSH)
+	{
+		out = pushQueue->size();
+	}
+	if (lq == LoggerQueue::POP)
+	{
+		out = popQueue->size();
+	}
+	unlock();
+	return out;
+}

--- a/src/ofxThreadedLogger.h
+++ b/src/ofxThreadedLogger.h
@@ -18,7 +18,7 @@
 
 #include "ofMain.h"
 
-#define LOGGER_THREAD_DEBUG // Comment out prior to release
+//#define LOGGER_THREAD_DEBUG // Comment out prior to release
 
 
 class LoggerThread : public ofThread {

--- a/src/ofxThreadedLogger.h
+++ b/src/ofxThreadedLogger.h
@@ -18,6 +18,8 @@
 
 #include "ofMain.h"
 
+#define LOGGER_THREAD_DEBUG
+
 
 class LoggerThread : public ofThread {
 private:
@@ -33,6 +35,8 @@ private:
 
 	queue<string> * pushQueue;	// Pointer to queue that's accepting incoming data
 	queue<string> * popQueue;	// Pointer to queue that's being written
+
+	size_t _pushThrottlingSize = SIZE_MAX / 2; // queue size trigger to impose a queue popping delay
 
 	void threadedFunction();	
 	void log(string logString);
@@ -59,6 +63,10 @@ public:
 		POP
 	};
 	size_t size(LoggerQueue lq);
+
+	// @brief Sets the queue size above which pushes are delayed to allow queue to pop
+	// @param pushThrottlingSize queue size trigger to impose a queue popping delay
+	void setPushThrottlingSize(size_t pushThrottlingSize = SIZE_MAX / 2);
 };
 
 

--- a/src/ofxThreadedLogger.h
+++ b/src/ofxThreadedLogger.h
@@ -52,6 +52,13 @@ public:
 	void setFilename(string filename);		
 	void push(string logString);
 	void stopThread();
+
+	enum LoggerQueue 
+	{
+		PUSH,
+		POP
+	};
+	size_t size(LoggerQueue lq);
 };
 
 

--- a/src/ofxThreadedLogger.h
+++ b/src/ofxThreadedLogger.h
@@ -18,7 +18,7 @@
 
 #include "ofMain.h"
 
-#define LOGGER_THREAD_DEBUG
+#define LOGGER_THREAD_DEBUG // Comment out prior to release
 
 
 class LoggerThread : public ofThread {
@@ -63,10 +63,17 @@ public:
 		PUSH,
 		POP
 	};
+
+	/*!
+		@brief Sets the queue size above which pushes are delayed to allow queue to pop
+		@return Size of specified queue
+	*/
 	size_t size(LoggerQueue lq);
 
-	// @brief Sets the queue size above which pushes are delayed to allow queue to pop
-	// @param pushThrottlingSize queue size trigger to impose a queue popping delay
+	/*!
+		@brief Returns size of PUSH or POP queue
+		@param pushThrottlingSize Queue size trigger to impose a queue popping delay
+	*/
 	void setPushThrottlingSize(size_t pushThrottlingSize = SIZE_MAX / 2);
 };
 

--- a/src/ofxThreadedLogger.h
+++ b/src/ofxThreadedLogger.h
@@ -37,6 +37,7 @@ private:
 	queue<string> * popQueue;	// Pointer to queue that's being written
 
 	size_t _pushThrottlingSize = SIZE_MAX / 2; // queue size trigger to impose a queue popping delay
+	int _loopSleep = 4;
 
 	void threadedFunction();	
 	void log(string logString);


### PR DESCRIPTION
# Description
- Adds book keeping functions to keep track of write thread size. This helps in tracking any runaway conditions, where the read thread overloads the write queue (since read is usually faster than write)

# PRs
- Required by https://github.com/EmotiBit/ofxEmotiBit/pull/161